### PR TITLE
fix: make generate_grpc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV PROTOBUF_VER_PY=4.24.3
 ENV PROTOC_GEN_GO_VER=v1.31.0
 ENV PROTOC_GEN_GO_GRPC_VER=v1.3.0
 
-RUN zypper -n addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/SLE_15/system:snappy.repo && \
+RUN zypper -n addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Factory/system:snappy.repo && \
     zypper --gpg-auto-import-keys ref
 
 # TODO: replace python311 with python3 if SLE upgrade system python version to python3.10+


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue None

#### What this PR does / why we need it:

Fix make generated_grpc failure.
```
 > [base  2/11] RUN zypper -n addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/SLE_15/system:snappy.repo &&     zypper --gpg-auto-import-keys ref:                                                       
1.045 Problem accessing the file at the specified URI:   
1.045 File '/repositories/system:/snappy/SLE_15/system:snappy.repo' not found on medium 'https://download.opensuse.org/'
1.045 Please check if the URI is valid and accessible.
```

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
